### PR TITLE
Fixed target DC mismatch issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# PyCharm
+.idea/
+
 # C extensions
 *.so
 

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -275,16 +275,32 @@ def get_user_info(samname, ldap_session, domain_dumper):
         return False
 
 
-
 def get_dc_host(ldap_session, domain_dumper):
     dc_host = None
-    ldap_session.search(domain_dumper.root, '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))', 
-            attributes=['name','dNSHostName'])
+    ldap_session.search(
+        domain_dumper.root,
+        '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))',
+        attributes=['name', 'dNSHostName']
+    )
     dd = ldap_session.entries[0]
     js = dd.entry_to_json()
     return json.loads(js)['attributes']
 
 
+def get_dc_hosts(ldap_session, domain_dumper):
+    dc_host = None
+    ldap_session.search(
+        domain_dumper.root,
+        '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))',
+        attributes=['name', 'dNSHostName']
+    )
+    dc_hosts = []
+    for dd in ldap_session.entries:
+        js = dd.entry_to_json()
+        attributes = json.loads(js)['attributes']
+        if len(attributes['name']) > 0:
+            dc_hosts.append(attributes)
+    return dc_hosts
 
 def get_domain_admins(ldap_session, domain_dumper):
     admins = []


### PR DESCRIPTION
Hi @WazeHell. Great work on this, tried in an engagement worked like a charm. I just changed a few things to make it a bit more flexible, such as:
- The .ccache files should not be removed at the end of the scripts, as they can be REUSED to regain access to the target host.
- If the domain hosts more than 1 DC, the original script will always take the first one (`get_dc_host`). However, sometimes the first DC may not be the target and may not even be vulnerable (As reported in #1). The new logic will fix #1, and attack the target specified in the parameter `dc-host`, if it's a DC. If the target is not a DC, the script will fallback to the first DC in the domain.
- I've also noticed you were trying to perform some validation on the account provided in the script, but you never used the parsed information anywhere, so I've introduced the logic to fix the account whenever the domain or the password are missing.

I've tested the new script and works quite well, but please get in touch if you need me to address anything else before merging.
